### PR TITLE
ch122170 Download the latest c-server-sdk release instead of a fixed version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,4 +47,4 @@ jobs:
       - run:
           name: Run hello
           command: |
-            LD_LIBRARY_PATH=. lua5.3 hello.lua
+            LD_LIBRARY_PATH=. lua5.1 hello.lua

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,13 @@ jobs:
       - checkout
       - run:
           name: Fetch System Dependenciesu
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre luarocks
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre lua@5.1 luarocks@5.
       - run:
           name: Download SDK
           command: ./download.sh
       - run:
           name: Build SDK
-          command: luarocks make launchdarkly-server-sdk-1.0-0.rockspec LD_DIR=. LD_INCDIR=./include
+          command: luarocks --lua-version=5.1 make launchdarkly-server-sdk-1.0-0.rockspec LD_DIR=. LD_INCDIR=./include
       - run:
           name: Run hello
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run:
           name: Fetch System Dependenciesu
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre lua@5.1 luarocks@5.
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre lua@5.1 luarocks
       - run:
           name: Download SDK
           command: ./download.sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ We've built a simple console application that demonstrates how LaunchDarkly's SD
 ## Dependencies
 Additionally you need the shared library for the LaunchDarkly `c-server-sdk`. You can automatically download the `lua-server-sdk`, and `c-server-sdk` with `download.sh`. The `c-server-sdk` shared library must be accessible be the linker at run-time. This project is built with `luarocks`.
 
+The `download.sh` script is not suitable for a production or CI environment.
+
 ## Instructions
 1. Install the dependencies described above
 2. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `hello.lua`

--- a/download.sh
+++ b/download.sh
@@ -1,24 +1,21 @@
 #!/bin/bash
 set -e
 
+download_sdk() {
+    echo "downloading $1 c-server-sdk shared library"
+    rm -rf $2 'include' 'lib'
+    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
+    grep browser_download_url | \
+    grep $2 | \
+    cut -d '"' -f 4 | \
+    xargs curl -s -o $2 -L
+    tar -xvf $2
+}
+
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    echo 'downloading linux c-server-sdk shared library'
-    rm -rf 'linux-gcc-64bit-dynamic.tar' 'include' 'lib'
-    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
-    grep browser_download_url | \
-    grep linux-gcc-64bit-dynamic.tar | \
-    cut -d '"' -f 4 | \
-    xargs curl -s -o 'linux-gcc-64bit-dynamic.tar' -L
-    tar -xvf 'linux-gcc-64bit-dynamic.tar'
+    download_sdk linux linux-gcc-64bit-dynamic.tar
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo 'downloading osx c-server-sdk shared library'
-    rm -rf 'osx-clang-64bit-dynamic.tar' 'include' 'lib'
-    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
-    grep browser_download_url | \
-    grep osx-clang-64bit-dynamic.tar | \
-    cut -d '"' -f 4 | \
-    xargs curl -s -o 'osx-clang-64bit-dynamic.tar' -L
-    tar -xvf 'osx-clang-64bit-dynamic.tar'
+    download_sdk osx osx-clang-64bit-dynamic.tar
 else
     echo "unknown platform"
     exit 1

--- a/download.sh
+++ b/download.sh
@@ -4,12 +4,20 @@ set -e
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     echo 'downloading linux c-server-sdk shared library'
     rm -rf 'linux-gcc-64bit-dynamic.tar' 'include' 'lib'
-    curl -s -o 'linux-gcc-64bit-dynamic.tar' -L 'https://github.com/launchdarkly/c-server-sdk/releases/download/2.2.1/linux-gcc-64bit-dynamic.tar'
+    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
+    grep browser_download_url | \
+    grep linux-gcc-64bit-dynamic.tar | \
+    cut -d '"' -f 4 | \
+    xargs curl -s -o 'linux-gcc-64bit-dynamic.tar' -L
     tar -xvf 'linux-gcc-64bit-dynamic.tar'
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     echo 'downloading osx c-server-sdk shared library'
     rm -rf 'osx-clang-64bit-dynamic.tar' 'include' 'lib'
-    curl -s -o "osx-clang-64bit-dynamic.tar" -L "https://github.com/launchdarkly/c-server-sdk/releases/download/2.2.1/osx-clang-64bit-dynamic.tar"
+    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
+    grep browser_download_url | \
+    grep osx-clang-64bit-dynamic.tar | \
+    cut -d '"' -f 4 | \
+    xargs curl -s -o 'osx-clang-64bit-dynamic.tar' -L
     tar -xvf 'osx-clang-64bit-dynamic.tar'
 else
     echo "unknown platform"

--- a/download.sh
+++ b/download.sh
@@ -1,10 +1,41 @@
 #!/bin/bash
 set -e
 
+# Download the c-server-sdk.
+#
+# $1: The platform the SDK is being downloaded for.
+# $2: The expected name of the SDK bundle file.
+# $3: Optional major version. Downloads the latest minor/patch unless specified.
+# $4: Optional minor version. Downloads the latest patch unless specified.
+# $5: Optional patch version.
+# Examples:
+#
+# Download the latest osx version.
+# download_sdk osx osx-clang-64bit-dynamic.tar
+#
+# Download the latest 2.x version for osx.
+# download_sdk osx osx-clang-64bit-dynamic.tar 2
+#
+# Download a specific version of the SDK.
+# download_sdk osx osx-clang-64bit-dynamic.tar 2 1 1
 download_sdk() {
     echo "downloading $1 c-server-sdk shared library"
     rm -rf $2 'include' 'lib'
-    curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/latest | \
+    major=${3:-[0-9]+}
+    minor=${4:-[0-9]+}
+    patch=${5:-[0-9]+}
+    #Get the list of releases.
+    #Trim that to a list of version numbers one on each line.
+    #Exclude any pre-release versions.
+    #Sort the versions from highest to lowest
+    #Take the first one.
+	curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases/tags/$(
+		curl https://api.github.com/repos/launchdarkly/c-server-sdk/releases | \
+        grep tag_name | \
+        cut -d '"' -f 4 | \
+        grep -E "$major\.$minor\.$patch$" | \
+        sort -V -r | \
+        head -n 1) | \
     grep browser_download_url | \
     grep $2 | \
     cut -d '"' -f 4 | \
@@ -12,6 +43,9 @@ download_sdk() {
     tar -xvf $2
 }
 
+# This will download the latest version of the SDK.
+# For a production application it would be preferable to download a specific
+# version. 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     download_sdk linux linux-gcc-64bit-dynamic.tar
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
This PR updates the `download.sh` script to download the latest version of the `c-server-sdk`.