### PR TITLE
Bump XCode to 12.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-test-osx:
     macos:
-      xcode: "11.4.0"
+      xcode: "12.5.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CircleCI no longer supports XCode < 12.5.1.