### PR TITLE
chore: Update README.md with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Please see [Lua Server SDK](https://github.com/launchdarkly/lua-server-sdk) for the most up-to-date `hello-lua-server`. This repo is deprecated.
+
 # LaunchDarkly sample Lua server-side application
 We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Lua reference guide](https://docs.launchdarkly.com/sdk/server-side/lua).
 

--- a/download.sh
+++ b/download.sh
@@ -62,7 +62,7 @@ rm -f launchdarkly-server-sdk.lua
 
 cp -r lib/* ./
 
-git clone https://github.com/launchdarkly/lua-server-sdk.git
+git clone --branch 1.2.2 --depth 1 https://github.com/launchdarkly/lua-server-sdk.git
 
 cp lua-server-sdk/launchdarkly-server-sdk.c ./
 cp lua-server-sdk/launchdarkly-server-sdk-1.0-0.rockspec ./


### PR DESCRIPTION
In Lua Server 2.0, the hello world application has moved into the repo itself in order to keep it up-to-date and relevant. 
This adds a note at the top of the README calling this out. 